### PR TITLE
[styles] Fixed remaining imports to @m-ui/styles

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Just add your audio link to `src` and your ready to go.
 
 ```javascript
 import { createMuiTheme } from '@material-ui/core';
-import { ThemeProvider } from '@material-ui/styles';
+import { ThemeProvider } from '@material-ui/core/styles';
 import AudioPlayer from 'material-ui-audio-player';
 
 const muiTheme = createMuiTheme({});
@@ -29,7 +29,7 @@ A bunch of props will help to customize component.
 
 ```javascript
 import { createMuiTheme } from '@material-ui/core';
-import { ThemeProvider } from '@material-ui/styles';
+import { ThemeProvider } from '@material-ui/core/styles';
 import AudioPlayer from 'material-ui-audio-player';
 
 const muiTheme = createMuiTheme({});
@@ -145,7 +145,7 @@ The attribute for customizing component styles. Accept the result of
 
 ```javascript
 import { createMuiTheme } from '@material-ui/core';
-import { ThemeProvider } from '@material-ui/styles';
+import { ThemeProvider } from '@material-ui/core/styles';
 import AudioPlayer from 'material-ui-audio-player';
 
 const muiTheme = createMuiTheme({});

--- a/src/components/AudioDownloadsControl.tsx
+++ b/src/components/AudioDownloadsControl.tsx
@@ -6,7 +6,7 @@ import {
   useMediaQuery
 } from '@material-ui/core';
 import { CloudDownload } from '@material-ui/icons';
-import { useTheme } from '@material-ui/styles';
+import { useTheme } from '@material-ui/core/styles';
 import cx from 'classnames';
 import * as React from 'react';
 import { IAudioPlayerColors } from './AudioPlayer';

--- a/src/components/AudioPlayer.tsx
+++ b/src/components/AudioPlayer.tsx
@@ -8,8 +8,8 @@ import {
 } from '@material-ui/core';
 // tslint:disable-next-line
 import { GridSpacing } from '@material-ui/core/Grid';
+import { useTheme } from '@material-ui/core/styles';
 import { Repeat } from '@material-ui/icons';
-import { useTheme } from '@material-ui/styles';
 // tslint:disable-next-line
 import { StylesHook } from '@material-ui/styles/makeStyles';
 import cx from 'classnames';

--- a/src/components/utils/enzymeHelpers.tsx
+++ b/src/components/utils/enzymeHelpers.tsx
@@ -1,4 +1,4 @@
-import { ThemeProvider } from '@material-ui/styles';
+import { ThemeProvider } from '@material-ui/core/styles';
 import { mount } from 'enzyme';
 import * as React from 'react';
 


### PR DESCRIPTION
There were a couple more references to @material-ui/styles in the imports to useStyles and ThemeProvider. They have been removed.