### PR TITLE
Format duration including hour

### DIFF
--- a/src/components/state/helpers.ts
+++ b/src/components/state/helpers.ts
@@ -3,10 +3,11 @@ export const appendZero = num => (num < 10 ? `0${num}` : num);
 export const getFormattedTime = time => {
   const dateTime = new Date(0, 0, 0, 0, 0, time, 0);
 
+  const dateTimeH = dateTime.getHours();
   const dateTimeM = appendZero(dateTime.getMinutes());
   const dateTimeS = appendZero(dateTime.getSeconds());
 
-  return `${dateTimeM}:${dateTimeS}`;
+  return (dateTimeH > 0 ? `${dateTimeH}:${dateTimeM}:${dateTimeS}` : `${dateTimeM}:${dateTimeS}`);
 };
 
 export const getProgress = (currentTime: number, duration: number) =>

--- a/src/components/state/helpers.ts
+++ b/src/components/state/helpers.ts
@@ -3,7 +3,7 @@ export const appendZero = num => (num < 10 ? `0${num}` : num);
 export const getFormattedTime = time => {
   const dateTime = new Date(0, 0, 0, 0, 0, time, 0);
 
-  const dateTimeH = dateTime.getHours();
+  const dateTimeH = appendZero(dateTime.getHours());
   const dateTimeM = appendZero(dateTime.getMinutes());
   const dateTimeS = appendZero(dateTime.getSeconds());
 


### PR DESCRIPTION
Make sense if someone (e.g. me) uses it for long form podcasts.

I have decided to not use a leading zero for the hour, but one could really debate this.