### PR TITLE
update mui theme imports

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,10 +28,10 @@ const muiTheme = createMuiTheme({});
 A bunch of props will help to customize component.
 
 ```javascript
-import { createMuiTheme, ThemeProvider } from '@material-ui/core';
+import { ThemeProvider, createTheme } from "@mui/material/styles";
 import AudioPlayer from 'material-ui-audio-player';
 
-const muiTheme = createMuiTheme({});
+const muiTheme = createTheme({});
 
 const src = [
   'https://www.soundhelix.com/examples/mp3/SoundHelix-Song-1.mp3',


### PR DESCRIPTION
I tried to import themeProvider from core mui but it didn't work.  Mui documentation offers to import from styles and in my case it worked. 

Versions that use: 

"typescript": "^4.9.3"
 "react": "^18.2.0",
 "@mui/material": "^5.10.17"
 

Also I realised that reateMuiTheme was deprecated.
link to issue: 
https://github.com/siriwatknp/mui-treasury/issues/1148

I hope it will help. This is my first pull request so don`t judge strictly )